### PR TITLE
feat: add `createCaptureStream` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ $ yarn add capture-all
 ## Example
 
 ```js
-import captureAll from 'capture-all'
-// or
-const captureAll = require('capture-all').default
-
+const { captureAll } = require('capture-all')
 const fs = require('fs')
 
 captureAll([
@@ -45,7 +42,7 @@ captureAll([
 
 ## API
 
-### `captureAll(targets: CaptureTarget[]): Promise<CaptureResult[]>`
+### `captureAll(targets: CaptureTarget[], options?: CaptureOptions): Promise<CaptureResult[]>`
 
 Capture screenshots of Web pages which specified by `targets` and return an array of `CaptureResult` object including captured image buffer.
 
@@ -56,6 +53,10 @@ Capture screenshots of Web pages which specified by `targets` and return an arra
 * `hidden`: an array of selector to hide matched elements from captured image
 * `viewport`: viewport size of browser
 
+`CaptureOptions` may have the following properties:
+
+* `concurrency`: a number of process which will be created for capture
+
 `CaptureResult` has the following properties:
 
 * `image`: captured image buffer
@@ -63,6 +64,10 @@ Capture screenshots of Web pages which specified by `targets` and return an arra
 * `target`: a selector of captured element
 * `hidden`: an array of selector which is hidden from captured image
 * `viewport`: viewport size of browser
+
+### `createCaptureStream(targets: CaptureTarget[], options?: CaptureOptions): ReadableStream<CaptureResult>`
+
+Similar to `captureAll` but returns readable stream of `CaptureResult` instead.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,15 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.6"
+      }
+    },
     "@types/jest": {
       "version": "22.1.4",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.1.4.tgz",
@@ -1278,10 +1287,9 @@
       }
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -2280,8 +2288,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
@@ -3279,7 +3286,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -4500,6 +4506,11 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+    },
     "test-exclude": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
@@ -4595,6 +4606,17 @@
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "yargs": {
@@ -4786,8 +4808,7 @@
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     }
   },
   "devDependencies": {
+    "@types/fs-extra": "^5.0.1",
     "@types/jest": "^22.1.4",
     "@types/puppeteer": "^1.0.1",
     "jest": "^22.4.2",
@@ -64,6 +65,8 @@
     "typescript": "^2.7.2"
   },
   "dependencies": {
-    "puppeteer": "^1.1.1"
+    "fs-extra": "^5.0.0",
+    "puppeteer": "^1.1.1",
+    "temp-dir": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "prepublishOnly": "npm run clean && npm run test && npm run build",
     "clean": "rm -rf lib",
     "build": "tsc -p src",
-    "dev": "jest --watch",
+    "dev": "npm run build && jest --watch",
     "lint": "tslint -p . && prettier --list-different \"{src,scripts,test}/**/*.{js,ts}\"",
     "format": "prettier --write \"{src,scripts,test}/**/*.{js,ts}\"",
     "test": "npm run lint && npm run test:unit",
-    "test:unit": "jest",
-    "snapshot": "jest --updateSnapshot"
+    "test:unit": "npm run build && jest",
+    "snapshot": "npm run build && jest --updateSnapshot"
   },
   "jest": {
     "transform": {

--- a/perf/test.js
+++ b/perf/test.js
@@ -1,0 +1,29 @@
+const path = require('path')
+const { performance } = require('perf_hooks')
+const { captureAll } = require('../')
+
+const N = 100
+const CONCURRENCY = 4
+
+function range(len) {
+  return Array.apply(null, Array(len)).map((_, i) => i)
+}
+
+const targets = range(N).map(() => {
+  return {
+    url:
+      'file://' +
+      path
+        .resolve(__dirname, '../test/fixture.html')
+        .split(path.sep)
+        .join('/')
+  }
+})
+
+performance.mark('start')
+captureAll(targets, { concurrency: CONCURRENCY }).then(() => {
+  performance.mark('end')
+  performance.measure('start to end', 'start', 'end')
+  const measure = performance.getEntriesByName('start to end')[0]
+  console.log(measure.duration / 1000 + 's')
+})

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -12,12 +12,9 @@ export interface CaptureParams {
 
 assert(process.send, 'capture.js must be executed in a child process')
 
-let browser: puppeteer.Browser | undefined
-let page: puppeteer.Page | undefined
-
 async function capture(target: CaptureParams): Promise<void> {
-  browser = browser || (await puppeteer.launch())
-  page = page || (await browser.newPage())
+  const browser = await puppeteer.launch()
+  const page = await browser.newPage()
 
   await page.goto(target.url)
   await page.setViewport(target.viewport)
@@ -33,6 +30,7 @@ async function capture(target: CaptureParams): Promise<void> {
   }
 
   await el.screenshot({ path: target.imagePath })
+  await browser.close()
 }
 
 function generateStyleToHide(selectors: string[]): string {
@@ -47,10 +45,4 @@ process.on('message', data => {
     .catch(err => {
       process.send!(err.message)
     })
-})
-
-process.on('exit', () => {
-  if (browser) {
-    browser.close()
-  }
 })

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -1,0 +1,54 @@
+import assert = require('assert')
+import * as puppeteer from 'puppeteer'
+import { CaptureTarget, CaptureResult } from './index'
+
+assert(process.send, 'capture.js must be executed in a child process')
+
+let browser: puppeteer.Browser | undefined
+let page: puppeteer.Page | undefined
+
+async function capture(
+  target: CaptureTarget
+): Promise<CaptureResult | undefined> {
+  browser = browser || (await puppeteer.launch())
+  page = page || (await browser.newPage())
+
+  await page.goto(target.url)
+  if (target.viewport) {
+    await page.setViewport(target.viewport)
+  }
+  if (target.hidden) {
+    await page.addStyleTag({
+      content: generateStyleToHide(target.hidden)
+    })
+  }
+
+  const el = await page.$(target.target || 'html')
+  if (!el) {
+    return
+  }
+
+  const image = await el.screenshot()
+
+  return {
+    image,
+    url: target.url,
+    target: target.target || 'html',
+    hidden: target.hidden || [],
+    viewport: page.viewport()
+  }
+}
+
+function generateStyleToHide(selectors: string[]): string {
+  return `${selectors.join(',')} { visibility: hidden !important; }`
+}
+
+process.on('message', data => {
+  capture(data)
+    .then(value => {
+      process.send!({ failed: false, value })
+    })
+    .catch(err => {
+      process.send!({ failed: true, error: err })
+    })
+})

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,155 @@
+import * as path from 'path'
+import { fork } from 'child_process'
+import { Stream, Readable, ReadableOptions } from 'stream'
+import { CaptureTarget, CaptureResult, CaptureOptions } from './index'
+
+export interface ReadableStream<T> extends NodeJS.ReadableStream, Stream {
+  push(data: T): boolean
+
+  addListener(event: 'close', listener: () => void): this
+  addListener(event: 'data', listener: (chunk: T) => void): this
+  addListener(event: 'end', listener: () => void): this
+  addListener(event: 'readable', listener: () => void): this
+  addListener(event: 'error', listener: (err: Error) => void): this
+  addListener(event: string, listener: (...args: any[]) => void): this
+
+  emit(event: 'close'): boolean
+  emit(event: 'data', chunk: T): boolean
+  emit(event: 'end'): boolean
+  emit(event: 'readable'): boolean
+  emit(event: 'error', err: Error): boolean
+  emit(event: string | symbol, ...args: any[]): boolean
+
+  on(event: 'close', listener: () => void): this
+  on(event: 'data', listener: (chunk: T) => void): this
+  on(event: 'end', listener: () => void): this
+  on(event: 'readable', listener: () => void): this
+  on(event: 'error', listener: (err: Error) => void): this
+  on(event: string, listener: (...args: any[]) => void): this
+
+  once(event: string, listener: (...args: any[]) => void): this
+  once(event: 'close', listener: () => void): this
+  once(event: 'data', listener: (chunk: T) => void): this
+  once(event: 'end', listener: () => void): this
+  once(event: 'readable', listener: () => void): this
+  once(event: 'error', listener: (err: Error) => void): this
+
+  prependListener(event: 'close', listener: () => void): this
+  prependListener(event: 'data', listener: (chunk: T) => void): this
+  prependListener(event: 'end', listener: () => void): this
+  prependListener(event: 'readable', listener: () => void): this
+  prependListener(event: 'error', listener: (err: Error) => void): this
+  prependListener(event: string, listener: (...args: any[]) => void): this
+
+  prependOnceListener(event: 'close', listener: () => void): this
+  prependOnceListener(event: 'data', listener: (chunk: T) => void): this
+  prependOnceListener(event: 'end', listener: () => void): this
+  prependOnceListener(event: 'readable', listener: () => void): this
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this
+  prependOnceListener(event: string, listener: (...args: any[]) => void): this
+
+  removeListener(event: 'close', listener: () => void): this
+  removeListener(event: 'data', listener: (chunk: T) => void): this
+  removeListener(event: 'end', listener: () => void): this
+  removeListener(event: 'readable', listener: () => void): this
+  removeListener(event: 'error', listener: (err: Error) => void): this
+  removeListener(event: string, listener: (...args: any[]) => void): this
+}
+
+export class ReadableStreamImpl extends Readable
+  implements ReadableStream<CaptureResult> {
+  remainingTargets: CaptureTarget[]
+  processes: ProcessWrapper[]
+
+  constructor(targets: CaptureTarget[], options: CaptureOptions) {
+    super({
+      objectMode: true
+    })
+    const concurrency = options.concurrency || 4
+    this.processes = range(concurrency).map(() => new ProcessWrapper())
+    this.remainingTargets = targets.slice()
+  }
+
+  teardown(): void {
+    this.processes.forEach(p => p.close())
+  }
+
+  startProcess(p: ProcessWrapper): void {
+    const target = this.remainingTargets.shift()
+    if (!target) {
+      if (this.finishedAllProcesses()) {
+        this.push(null)
+        this.teardown()
+      }
+      return
+    }
+
+    p
+      .run(target)
+      .then(result => {
+        if (!result) {
+          return this.startProcess(p)
+        }
+
+        const shouldContinue = this.push(result)
+        if (shouldContinue) {
+          return this.startProcess(p)
+        }
+      })
+      .catch(err => {
+        debugger
+        process.nextTick(() => this.emit('error', err))
+        this.teardown()
+      })
+  }
+
+  finishedAllProcesses(): boolean {
+    return this.processes.every(p => !p.isRunning)
+  }
+
+  _read(size: number): void {
+    this.processes.filter(p => !p.isRunning).forEach(p => {
+      this.startProcess(p)
+    })
+  }
+
+  _destroy(err: Error, callback: Function): void {
+    super._destroy(err, callback)
+    this.teardown()
+  }
+}
+
+export class ProcessWrapper {
+  private cp = process.env.NODE_ENV === 'test'
+    ? fork(path.resolve(__dirname, '../lib/capture'), [], {
+        stdio: 'inherit' as any
+      })
+    : fork(require.resolve('./capture'))
+  isRunning = false
+
+  run(target: CaptureTarget): Promise<CaptureResult | undefined> {
+    debugger
+    return new Promise((resolve, reject) => {
+      this.isRunning = true
+      this.cp.send(target)
+      this.cp.once('message', result => {
+        this.isRunning = false
+        if (result.failed) {
+          return reject(result.error)
+        }
+        resolve(result.value)
+      })
+      this.cp.once('error', err => {
+        reject(err)
+      })
+    })
+  }
+
+  close(): void {
+    this.cp.kill()
+  }
+}
+
+function range(len: number): number[] {
+  return Array.apply(null, Array(len)).map((_: any, i: number) => i)
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -85,6 +85,10 @@ export class ReadableStreamImpl extends Readable
   }
 
   startProcess(p: ProcessWrapper): void {
+    if (p.isRunning) {
+      return
+    }
+
     const target = this.remainingTargets.shift()
     if (!target) {
       if (this.finishedAllProcesses() && !this.torndown) {
@@ -117,7 +121,7 @@ export class ReadableStreamImpl extends Readable
   }
 
   _read(size: number): void {
-    this.processes.filter(p => !p.isRunning).forEach(p => {
+    this.processes.forEach(p => {
       this.startProcess(p)
     })
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -135,6 +135,7 @@ export class ProcessWrapper {
   run(target: CaptureTarget): Promise<CaptureResult | undefined> {
     const imagePath =
       path.join(tempDir, `${Date.now()}-${Math.random().toString(16)}`) + '.png'
+
     const params: CaptureParams = {
       url: target.url,
       target: target.target || 'html',

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,3 +1,4 @@
+import assert = require('assert')
 import * as path from 'path'
 import * as fse from 'fs-extra'
 import { fork } from 'child_process'
@@ -69,7 +70,9 @@ export class ReadableStreamImpl extends Readable
     super({
       objectMode: true
     })
-    const concurrency = options.concurrency || 4
+    assert(targets.length > 0, 'capture target must have at least one')
+
+    const concurrency = Math.min(targets.length, options.concurrency || 4)
     this.processes = range(concurrency).map(() => new ProcessWrapper())
     this.remainingTargets = targets.slice()
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+declare module 'temp-dir' {
+  const dir: string
+  export = dir
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import captureAll from '../src/index'
+import { captureAll } from '../src/index'
 
 describe('Snapshot test', async () => {
   const fixtureUrl = 'file://' + path.resolve(__dirname, 'fixture.html')

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,11 +1,13 @@
 import * as path from 'path'
-import { captureAll } from '../src/index'
+import { captureAll, createCaptureStream } from '../src/index'
 
 describe('Snapshot test', async () => {
   const fixtureUrl = 'file://' + path.resolve(__dirname, 'fixture.html')
 
   it('should capture web page', async () => {
-    const res = await captureAll([{ url: fixtureUrl }])
+    const res = await captureAll([{ url: fixtureUrl }], {
+      concurrency: 1
+    })
     expect(res[0].url).toBe(fixtureUrl)
     expect(res[0].target).toBe('html')
     expect(res[0].hidden).toEqual([])
@@ -53,6 +55,25 @@ describe('Snapshot test', async () => {
     expect(res[0].viewport).toEqual({
       width: 320,
       height: 480
+    })
+  })
+
+  it('should create capture stream', done => {
+    const mock = jest.fn()
+    const stream = createCaptureStream(
+      [
+        {
+          url: fixtureUrl
+        }
+      ],
+      {
+        concurrency: 1
+      }
+    )
+    stream.on('data', mock)
+    stream.on('end', () => {
+      expect(mock).toHaveBeenCalledTimes(1)
+      done()
     })
   })
 })


### PR DESCRIPTION
This PR adds a new function `createCaptureStream` which generates a readable stream providing capture results. Also added a `concurrency` option both `captureAll` and `createCaptureStream`.

The capturing process is now executed on forked process and it let us make it concurrently. So I guess it improves performance when the users want to capture a large amount of screenshots.

There are two breaking changes for this addition:

* `target` selector no longe pick multiple elements. It is now only capture the first matched element.
* `captureAll` no longe be default export. It is now named export.